### PR TITLE
fix(app): sCRUM-1246,1241,1240,1243,1242,1244,1248,1247,1245

### DIFF
--- a/src/Catalogue/CatalogueBill/CatalogueBill.tsx
+++ b/src/Catalogue/CatalogueBill/CatalogueBill.tsx
@@ -91,6 +91,7 @@ export interface CatalogueInvoiceData {
   extraExpenseName?: string;
   extraExpenseAmount?: number;
   discountDisplayMode?: 'amount' | 'percentage';
+  enableDiscount2?: boolean;
 }
 export const CatalogueBill = async (
   data: CatalogueInvoiceData,
@@ -393,9 +394,15 @@ export const CatalogueBill = async (
     const printTaxRate = isComposition ? "-" : `${taxRate}%`;
     const printTaxAmt = isComposition ? "-" : taxAmt.toFixed(2);
 
-    const discDisplay = data.discountDisplayMode === 'percentage'
-      ? `${disc1Pct.toFixed(2)}% + ${disc2Pct.toFixed(2)}%`
-      : `${disc1Amt.toFixed(2)} + ${disc2Amt.toFixed(2)}`;
+    const showDiscount2 = data.enableDiscount2 === true;
+
+    const discDisplay = showDiscount2
+      ? (data.discountDisplayMode === 'percentage'
+        ? `${disc1Pct.toFixed(2)}% + ${disc2Pct.toFixed(2)}%`
+        : `${disc1Amt.toFixed(2)} + ${disc2Amt.toFixed(2)}`)
+      : (data.discountDisplayMode === 'percentage'
+        ? `${disc1Pct.toFixed(2)}%`
+        : `${disc1Amt.toFixed(2)}`);
 
     if (!showTaxColumns) {
       return [
@@ -1055,5 +1062,6 @@ export const prepareCatalogueBillData = async (invoiceData: any) => {
     signatureBase64: billSettings.signatureBase64 || "",
     enableTriplicate: billSettings.enableTriplicate || false,
     discountDisplayMode: billSettings.discountDisplayFormat || invoiceData.discountDisplayFormat || 'amount',
+    enableDiscount2: salesSettings?.enableDiscount2 || false,
   };
 };

--- a/src/Catalogue/CatalogueBill/CatalogueBill.tsx
+++ b/src/Catalogue/CatalogueBill/CatalogueBill.tsx
@@ -677,7 +677,7 @@ export const CatalogueBill = async (
     if (!hasExpensesAbove) doc.line(startX, finalY, endX, finalY); // top (only if no expenses above)
     doc.line(startX, finalY + 6, endX, finalY + 6);                // bottom
     doc.line(vBoxX, finalY, vBoxX, finalY + 6);
-    doc.setFontSize(9); doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9); doc.setFont('helvetica', 'normal');
     doc.text('Add : Rounded off (+)', vBoxX - 2, finalY + 4, { align: 'right' });
     doc.text(roundOffAmt.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }), endX - 2, finalY + 4, { align: 'right' });
     finalY += 6;
@@ -698,7 +698,7 @@ export const CatalogueBill = async (
       doc.line(endX, finalY, endX, finalY + 6);           // right
       doc.line(startX, finalY, endX, finalY);             // top
       doc.line(vBoxX, finalY, vBoxX, finalY + 6);
-      doc.setFontSize(9); doc.setFont('helvetica', 'bold');
+      doc.setFontSize(9); doc.setFont('helvetica', 'normal');
       doc.text('Advance Paid (-)', vBoxX - 2, finalY + 4, { align: 'right' });
       doc.text(advance.toLocaleString('en-IN', { minimumFractionDigits: 2 }), endX - 2, finalY + 4, { align: 'right' });
       finalY += 6;
@@ -771,7 +771,7 @@ export const CatalogueBill = async (
       doc.line(divX, finalY, divX, finalY + wordsH); doc.line(divX, finalY + 6, endX, finalY + 6);
       doc.setFont('helvetica', 'normal'); doc.text('Previous Balance :', divX + 2, finalY + 4.5);
       doc.text(prevBal.toLocaleString('en-IN', { minimumFractionDigits: 2 }), endX - 2, finalY + 4.5, { align: 'right' });
-      doc.setFont('helvetica', 'bold'); doc.text('Balance Due :', divX + 2, finalY + 10);
+      doc.setFont('helvetica', 'bold'); doc.text('Total Balance Due :', divX + 2, finalY + 10);
       doc.text(totalDue.toLocaleString('en-IN', { minimumFractionDigits: 2 }), endX - 2, finalY + 10, { align: 'right' });
     }
     finalY += wordsH;
@@ -815,9 +815,10 @@ export const CatalogueBill = async (
 
     doc.setFont('helvetica', 'normal');
     let mx = (pageWidth / 2) - ((doc.getTextWidth("Made with ") + doc.getTextWidth("Love") + doc.getTextWidth(" in India")) / 2);
+    doc.setTextColor(0, 0, 0);
     doc.text("Made with ", mx, by + 10); mx += doc.getTextWidth("Made with ");
-    doc.setTextColor(255, 0, 0); doc.text("Love", mx, by + 10); mx += doc.getTextWidth("Love");
-    doc.setTextColor(0, 0, 139); doc.text(" in India", mx, by + 10); doc.setTextColor(0);
+    doc.text("Love", mx, by + 10); mx += doc.getTextWidth("Love");
+    doc.text(" in India", mx, by + 10); doc.setTextColor(0);
   };
 
   renderPage(false);

--- a/src/Catalogue/CatalogueHome.tsx
+++ b/src/Catalogue/CatalogueHome.tsx
@@ -76,19 +76,25 @@ const useBusinessName = (userId?: string, companyId?: string) => {
 
     return { businessName, loading };
 };
-// AFTER
+const getSampleChartData = (): ChartDataPoint[] => {
+    const sales = [4200, 5600, 3100, 6800, 4900, 7200, 4700];
+    const bills = [10, 13, 8, 16, 12, 17, 8];
+    const today = new Date();
+
+    return sales.map((amount, i) => {
+        const d = new Date(today);
+        d.setDate(d.getDate() - (sales.length - 1 - i)); // last 7 days ending today
+        return {
+            date: d.toLocaleDateString('en-CA'), // matches YYYY-MM-DD key used elsewhere
+            sales: amount,
+            bills: bills[i],
+        };
+    });
+};
 const SAMPLE_CATALOGUE_DATA: CatalogueDashboardData = {
     totalSalesAmount: 36500,
     totalSalesCount: 84,
-    chartData: [
-        { date: '2026-07-01', sales: 4200, bills: 10 },
-        { date: '2026-07-02', sales: 5600, bills: 13 },
-        { date: '2026-07-03', sales: 3100, bills: 8 },
-        { date: '2026-07-04', sales: 6800, bills: 16 },
-        { date: '2026-07-05', sales: 4900, bills: 12 },
-        { date: '2026-07-06', sales: 7200, bills: 17 },
-        { date: '2026-07-07', sales: 4700, bills: 8 },
-    ],
+    chartData: getSampleChartData(),
     topByQuantity: [
         { id: 'sample-1', name: 'Sample Item A', totalQuantity: 42, totalAmount: 8400 },
         { id: 'sample-2', name: 'Sample Item B', totalQuantity: 31, totalAmount: 6200 },
@@ -175,7 +181,11 @@ const HomePageContent: React.FC = () => {
     const [data, setData] = useState<WithCacheMeta<CatalogueDashboardData> | null>(null);
     const [loading, setLoading] = useState(true);
 
-    const displayData = isTutorialActive ? SAMPLE_CATALOGUE_DATA : data;
+    const sampleData = useMemo(
+    () => ({ ...SAMPLE_CATALOGUE_DATA, chartData: getSampleChartData() }),
+    [] 
+);
+const displayData = isTutorialActive ? sampleData : data;
     const effectiveDataVisible = isTutorialActive ? true : isDataVisible;
 
     const fetchData = useCallback(async (forceRefresh = false) => {

--- a/src/Catalogue/CheckOut.tsx
+++ b/src/Catalogue/CheckOut.tsx
@@ -594,17 +594,8 @@ const CartPage: React.FC = () => {
             item: { ...i },
             quantity: i.quantity
         }))));
-        if (updatedCart.length === 0) {
-            // If cart is now empty, wipe the upcoming doc's items too
-            const userKey = localStorage.getItem("upcoming_user_key");
-            if (userKey && effectiveCompanyId) {
-                const orderRef = doc(db, "companies", effectiveCompanyId, "Orders", `upcoming_${userKey}`);
-                setDoc(orderRef, { items: [], totalAmount: 0, updatedAt: serverTimestamp() }, { merge: true })
-                    .catch(err => console.error("Empty cart sync error:", err));
-            }
-        } else {
-            syncToUpcoming(updatedCart);
-        }
+
+        syncToUpcoming(updatedCart);
     };
 
     useEffect(() => {

--- a/src/Catalogue/Orders.tsx
+++ b/src/Catalogue/Orders.tsx
@@ -1881,6 +1881,14 @@ const OrdersPage: React.FC = () => {
                 acc[status] = Orders.filter(
                     o => o.status === "Completed" || o.status === "Paid"
                 ).length;
+            } else if (status === "Upcoming") {
+                acc[status] = Orders.filter(o => {
+                    if (o.status !== "Upcoming") return false;
+                    if (o.isLead) {
+                        return (o.items?.length || 0) > 0;
+                    }
+                    return true;
+                }).length;
             } else {
                 acc[status] = Orders.filter(
                     o => o.status === status
@@ -3479,7 +3487,7 @@ const OrdersPage: React.FC = () => {
                                                 {(
                                                     <div
                                                         className={`grid ${isUpcomingStatus
-                                                            ? Order.userLoginPhone ? 'grid-cols-3' : 'grid-cols-1'
+                                                            ? Order.userLoginPhone ? 'grid-cols-4' : 'grid-cols-2'
                                                             : Order.status === "Packed"
                                                                 ? 'grid-cols-5 md:grid-cols-5'
                                                                 : Order.status === "Paid"
@@ -3495,7 +3503,7 @@ const OrdersPage: React.FC = () => {
                                                                 <a
                                                                     href={`tel:${Order.userLoginPhone.replace(/\D/g, '')}`}
                                                                     onClick={(e) => e.stopPropagation()}
-                                                                    className="py-2.5 bg-white border border-emerald-200 text-emerald-600 text-xs font-bold rounded-sm text-center"
+                                                                    className="py-2.5 bg-emerald-500 text-white text-xs font-bold rounded-sm text-center"
                                                                 >
                                                                     Call
                                                                 </a>
@@ -3505,10 +3513,45 @@ const OrdersPage: React.FC = () => {
                                                                     target="_blank"
                                                                     rel="noopener noreferrer"
                                                                     onClick={(e) => e.stopPropagation()}
-                                                                    className="py-2.5 bg-[#25D366] text-white text-xs font-bold rounded-sm text-center"
+                                                                    className="py-2.5 bg-black text-white text-xs font-bold rounded-sm text-center"
                                                                 >
                                                                     WhatsApp
                                                                 </a>
+                                                                <button
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        setSelectedOrderForAction(Order);
+                                                                    }}
+                                                                    disabled={pdfLoadingOrderId === Order.id}
+                                                                    className="py-2.5 bg-blue-600 text-white text-xs font-bold rounded-sm flex items-center justify-center"
+                                                                >
+                                                                    {pdfLoadingOrderId === Order.id ? <Spinner /> : "Print"}
+                                                                </button>
+                                                                <button
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        handleDeleteOrder(Order.id);
+                                                                    }}
+                                                                    className="py-2.5 bg-[#FF3B30] text-white text-xs font-bold rounded-sm cursor-pointer"
+                                                                >
+                                                                    Delete
+                                                                </button>
+                                                            </>
+                                                        )}
+                                                        {/* NEW: fallback for upcoming/lead orders that have no phone captured yet —
+    still let the seller print/download the bill */}
+                                                        {isUpcomingStatus && !Order.userLoginPhone && (
+                                                            <>
+                                                                <button
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        setSelectedOrderForAction(Order);
+                                                                    }}
+                                                                    disabled={pdfLoadingOrderId === Order.id}
+                                                                    className="py-2.5 bg-blue-600 text-white text-xs font-bold rounded-sm flex items-center justify-center"
+                                                                >
+                                                                    {pdfLoadingOrderId === Order.id ? <Spinner /> : "Print"}
+                                                                </button>
 
                                                                 <button
                                                                     onClick={(e) => {
@@ -3521,7 +3564,6 @@ const OrdersPage: React.FC = () => {
                                                                 </button>
                                                             </>
                                                         )}
-
                                                         {!isUpcomingStatus && (isFinalStage ? (
                                                             <>
 

--- a/src/Catalogue/Orders.tsx
+++ b/src/Catalogue/Orders.tsx
@@ -1392,7 +1392,7 @@ const OrdersPage: React.FC = () => {
                 customer: {
                     billing: {
                         name: Order.billingDetails?.name || Order.userName || "Customer",
-                        phone: Order.billingDetails?.phone || "",
+                        phone: Order.billingDetails?.phone || Order.userLoginPhone || "",
                         address: Order.billingDetails?.address || "",
                         city: Order.billingDetails?.city || "",
                         state: Order.billingDetails?.state || "",
@@ -1527,7 +1527,7 @@ const OrdersPage: React.FC = () => {
                 customer: {
                     billing: {
                         name: Order.billingDetails?.name || Order.userName || "Customer",
-                        phone: Order.billingDetails?.phone || "",
+                        phone: Order.billingDetails?.phone || Order.userLoginPhone || "",
                         address: Order.billingDetails?.address || "",
                         city: Order.billingDetails?.city || "",
                         state: Order.billingDetails?.state || "",
@@ -1690,7 +1690,7 @@ const OrdersPage: React.FC = () => {
                 customer: {
                     billing: {
                         name: Order.billingDetails?.name || Order.userName || "Customer",
-                        phone: Order.billingDetails?.phone || "",
+                        phone: Order.billingDetails?.phone || Order.userLoginPhone || "",
                         address: Order.billingDetails?.address || "",
                         city: Order.billingDetails?.city || "",
                         state: Order.billingDetails?.state || "",
@@ -1881,14 +1881,6 @@ const OrdersPage: React.FC = () => {
                 acc[status] = Orders.filter(
                     o => o.status === "Completed" || o.status === "Paid"
                 ).length;
-            } else if (status === "Upcoming") {
-                acc[status] = Orders.filter(o => {
-                    if (o.status !== "Upcoming") return false;
-                    if (o.isLead) {
-                        return (o.items?.length || 0) > 0;
-                    }
-                    return true;
-                }).length;
             } else {
                 acc[status] = Orders.filter(
                     o => o.status === status
@@ -3503,7 +3495,7 @@ const OrdersPage: React.FC = () => {
                                                                 <a
                                                                     href={`tel:${Order.userLoginPhone.replace(/\D/g, '')}`}
                                                                     onClick={(e) => e.stopPropagation()}
-                                                                    className="py-2.5 bg-emerald-500 text-white text-xs font-bold rounded-sm text-center"
+                                                                    className="min-h-[44px] py-2.5 bg-blue-600 text-white text-xs font-bold rounded-sm text-center"
                                                                 >
                                                                     Call
                                                                 </a>
@@ -3513,7 +3505,7 @@ const OrdersPage: React.FC = () => {
                                                                     target="_blank"
                                                                     rel="noopener noreferrer"
                                                                     onClick={(e) => e.stopPropagation()}
-                                                                    className="py-2.5 bg-black text-white text-xs font-bold rounded-sm text-center"
+                                                                    className="min-h-[44px] py-2.5 bg-emerald-500 text-white text-xs font-bold rounded-sm text-center"
                                                                 >
                                                                     WhatsApp
                                                                 </a>
@@ -3523,7 +3515,7 @@ const OrdersPage: React.FC = () => {
                                                                         setSelectedOrderForAction(Order);
                                                                     }}
                                                                     disabled={pdfLoadingOrderId === Order.id}
-                                                                    className="py-2.5 bg-blue-600 text-white text-xs font-bold rounded-sm flex items-center justify-center"
+                                                                    className="min-h-[44px] py-2.5 bg-black text-white text-xs font-bold rounded-sm flex items-center justify-center"
                                                                 >
                                                                     {pdfLoadingOrderId === Order.id ? <Spinner /> : "Print"}
                                                                 </button>
@@ -3532,7 +3524,7 @@ const OrdersPage: React.FC = () => {
                                                                         e.stopPropagation();
                                                                         handleDeleteOrder(Order.id);
                                                                     }}
-                                                                    className="py-2.5 bg-[#FF3B30] text-white text-xs font-bold rounded-sm cursor-pointer"
+                                                                    className="min-h-[44px] py-2.5 bg-[#FF3B30] text-white text-xs font-bold rounded-sm cursor-pointer"
                                                                 >
                                                                     Delete
                                                                 </button>

--- a/src/Catalogue/Settings/CatalogueBillSetting.tsx
+++ b/src/Catalogue/Settings/CatalogueBillSetting.tsx
@@ -164,7 +164,7 @@ const CatalogueBillSettings: React.FC = () => {
         const { name, value } = e.target;
         setSettings(prev => ({ ...prev, [name]: value }));
     };
-     // Handle boolean toggles (e.g. Triplicate switch)
+    // Handle boolean toggles (e.g. Triplicate switch)
     const handleToggle = (name: keyof BillSettingsData, value: boolean) => {
         setSettings(prev => ({ ...prev, [name]: value }));
     };
@@ -307,7 +307,7 @@ const CatalogueBillSettings: React.FC = () => {
                                     <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
                                         REGISTERED ADDRESS
                                     </label>
-                                    <div className="p-3 bg-gray-50 border border-gray-200 rounded-sm text-gray-800 font-medium h-[44px] flex truncate items-center">
+                                    <div className="p-3 bg-gray-50 border border-gray-200 rounded-sm text-gray-800 font-medium min-h-[44px] flex items-center whitespace-normal break-words">
                                         {businessInfo.address}
                                     </div>
                                 </div>
@@ -499,7 +499,7 @@ const CatalogueBillSettings: React.FC = () => {
                                 <div className="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
                             </label>
                         </div>
-                    {/* NEW: Discount 1 + Discount 2 display format */}
+                        {/* NEW: Discount 1 + Discount 2 display format */}
                         <div className="mt-5 pt-5 border-t border-gray-100">
                             <div className="rounded-sm bg-gray-50 border border-gray-100 p-3">
                                 <div className="flex items-center gap-2 mb-2">

--- a/src/Catalogue/Settings/CatalogueSalesSetting.tsx
+++ b/src/Catalogue/Settings/CatalogueSalesSetting.tsx
@@ -128,7 +128,6 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
           <label htmlFor={id} className="text-sm font-semibold text-gray-800 leading-5">{label}</label>
           <InfoTooltip text={tooltip || description} />
         </div>
-        <p className="hidden md:block text-xs text-gray-500 mt-1 leading-relaxed">{description}</p>
       </div>
     </div>
     <label htmlFor={id} className="relative inline-flex cursor-pointer items-center">
@@ -353,61 +352,6 @@ const CatalogueSalesSettings: React.FC = () => {
       <main className="flex-grow min-h-0 p-3 sm:p-4 md:p-5 bg-gray-50 w-full overflow-y-auto box-border pb-44 md:pb-24">
         <form onSubmit={handleSave} className="max-w-5xl mx-auto space-y-5">
 
-          {/* ── Inventory & Stock ─────────────────────────────────────────── */}
-          <SettingsCard title="Inventory & Stock" icon={<PackageX size={18} />}>
-            <ToggleRow
-              id="allow-negative-inventory"
-              label="Allow Negative Inventory"
-              description="Allow orders even when stock is zero."
-              checked={settings.allowNegativeInventory}
-              onChange={(checked) => handleCheckboxChange('allowNegativeInventory', checked)}
-              tooltip="Permit catalogue orders for items with no recorded stock."
-              icon={<PackageX size={18} />}
-            />
-
-            <ToggleRow
-              id="Hide Out of Stock Items"
-              label="Hide Out of Stock Items"
-              description="Hide Out of Stock Items."
-              checked={settings.hideOutOfStock ?? false}
-              onChange={(checked) => handleCheckboxChange('hideOutOfStock', checked)}
-              tooltip="Hide Out Of Stock Items from Customers."
-              icon={<EyeOff size={18} />}
-            />
-
-            <ToggleRow
-              id="enable-out-of-stock-notification"
-              label="Enable 'Notify Me' Button"
-              description="Show a 'Notify Me' button on out-of-stock products so customers can request restock alerts."
-              checked={settings.enableOutOfStockNotification ?? false}
-              onChange={(checked) => handleCheckboxChange('enableOutOfStockNotification', checked)}
-              tooltip="When enabled, customers will see a 'Notify Me' button instead of 'Add to Cart' for out-of-stock items. Their requests appear in the Pre-Order Requests page."
-              icon={<BellRing size={18} />}
-            />
-          </SettingsCard>
-
-          {/* ── Customer Access ───────────────────────────────────────────── */}
-          <SettingsCard title="Customer Access" icon={<ShieldCheck size={18} />}>
-            <ToggleRow
-              id="hide-price"
-              label="Hide Price from Customers"
-              description="Prices will not be visible on the catalogue."
-              checked={settings.hidePrice ?? false}
-              onChange={(checked) => handleCheckboxChange('hidePrice', checked)}
-              tooltip="Completely hides item prices on the customer-facing catalogue."
-              icon={<EyeOff size={18} />}
-            />
-            <ToggleRow
-              id="require-approval"
-              label="Require Customer Approval"
-              description="Customers must submit a request and be approved before they can view prices or add items to cart."
-              checked={settings.requireApproval ?? false}
-              onChange={(checked) => handleCheckboxChange('requireApproval', checked)}
-              tooltip="Enables an approval gate — customers fill a lead form and you manually approve or decline them."
-              icon={<ShieldCheck size={18} />}
-            />
-          </SettingsCard>
-
           <SettingsCard title="Pricing & Tax" icon={<Percent size={18} />}>
             <div className="space-y-3">
               <ToggleRow
@@ -419,7 +363,7 @@ const CatalogueSalesSettings: React.FC = () => {
                 tooltip="Allow discounts to be applied to individual cart items."
                 icon={<Percent size={18} />}
               />
-               <ToggleRow
+              <ToggleRow
                 id="item-discount-2"
                 label="Enable Second Discount (Disc2)"
                 description="Show a second discount field, applied on top of Disc1."
@@ -481,6 +425,63 @@ const CatalogueSalesSettings: React.FC = () => {
               )}
             </div>
           </SettingsCard>
+
+          {/* ── Inventory & Stock ─────────────────────────────────────────── */}
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-5">
+            <SettingsCard title="Inventory & Stock" icon={<PackageX size={18} />}>
+              <ToggleRow
+                id="allow-negative-inventory"
+                label="Allow Negative Inventory"
+                description="Allow orders even when stock is zero."
+                checked={settings.allowNegativeInventory}
+                onChange={(checked) => handleCheckboxChange('allowNegativeInventory', checked)}
+                tooltip="Permit catalogue orders for items with no recorded stock."
+                icon={<PackageX size={18} />}
+              />
+
+              <ToggleRow
+                id="Hide Out of Stock Items"
+                label="Hide Out of Stock Items"
+                description="Hide Out of Stock Items."
+                checked={settings.hideOutOfStock ?? false}
+                onChange={(checked) => handleCheckboxChange('hideOutOfStock', checked)}
+                tooltip="Hide Out Of Stock Items from Customers."
+                icon={<EyeOff size={18} />}
+              />
+
+              <ToggleRow
+                id="enable-out-of-stock-notification"
+                label="Enable 'Notify Me' Button"
+                description="Show a 'Notify Me' button on out-of-stock products so customers can request restock alerts."
+                checked={settings.enableOutOfStockNotification ?? false}
+                onChange={(checked) => handleCheckboxChange('enableOutOfStockNotification', checked)}
+                tooltip="When enabled, customers will see a 'Notify Me' button instead of 'Add to Cart' for out-of-stock items. Their requests appear in the Pre-Order Requests page."
+                icon={<BellRing size={18} />}
+              />
+            </SettingsCard>
+
+            {/* ── Customer Access ───────────────────────────────────────────── */}
+            <SettingsCard title="Customer Access" icon={<ShieldCheck size={18} />}>
+              <ToggleRow
+                id="hide-price"
+                label="Hide Price from Customers"
+                description="Prices will not be visible on the catalogue."
+                checked={settings.hidePrice ?? false}
+                onChange={(checked) => handleCheckboxChange('hidePrice', checked)}
+                tooltip="Completely hides item prices on the customer-facing catalogue."
+                icon={<EyeOff size={18} />}
+              />
+              <ToggleRow
+                id="require-approval"
+                label="Require Customer Approval"
+                description="Customers must submit a request and be approved before they can view prices or add items to cart."
+                checked={settings.requireApproval ?? false}
+                onChange={(checked) => handleCheckboxChange('requireApproval', checked)}
+                tooltip="Enables an approval gate — customers fill a lead form and you manually approve or decline them."
+                icon={<ShieldCheck size={18} />}
+              />
+            </SettingsCard>
+          </div>
 
           {/* ── Order Rules & Voucher in a 2-col grid ──────────────────────── */}
           <div className="grid grid-cols-1 xl:grid-cols-2 gap-5">

--- a/src/Catalogue/SharedProduct.tsx
+++ b/src/Catalogue/SharedProduct.tsx
@@ -330,7 +330,32 @@ const SharedProduct: React.FC = () => {
     const syncToUpcoming = async (
         updatedCart: { item: Item; quantity: number }[]
     ) => {
-        if (!effectiveCompanyId || updatedCart.length === 0) return;
+        if (!effectiveCompanyId) return;
+
+        if (updatedCart.length === 0) {
+            const userKey = localStorage.getItem("upcoming_user_key");
+            if (!userKey) return;
+            try {
+                const orderRef = doc(
+                    db,
+                    "companies",
+                    effectiveCompanyId,
+                    "Orders",
+                    `upcoming_${userKey}`
+                );
+                const snap = await getDoc(orderRef);
+                if (snap.exists()) {
+                    await setDoc(
+                        orderRef,
+                        { items: [], totalAmount: 0, updatedAt: serverTimestamp() },
+                        { merge: true }
+                    );
+                }
+            } catch (err) {
+                console.error("Sync Upcoming (empty cart) error:", err);
+            }
+            return;
+        }
 
         const leadSubmittedCheck = localStorage.getItem("leadSubmitted") === "true";
         if (approvalEnabled && !leadSubmittedCheck) return;
@@ -437,10 +462,14 @@ const SharedProduct: React.FC = () => {
         }
     };
 
+    const isInitialCartSyncRef = useRef(true);
+
     useEffect(() => {
-        if (cart.length > 0) {
-            syncToUpcoming(cart);
+        if (isInitialCartSyncRef.current) {
+            isInitialCartSyncRef.current = false;
+            return;
         }
+        syncToUpcoming(cart);
     }, [cart]);
 
     useEffect(() => {

--- a/src/Catalogue/SharedProduct.tsx
+++ b/src/Catalogue/SharedProduct.tsx
@@ -330,32 +330,7 @@ const SharedProduct: React.FC = () => {
     const syncToUpcoming = async (
         updatedCart: { item: Item; quantity: number }[]
     ) => {
-        if (!effectiveCompanyId) return;
-
-        if (updatedCart.length === 0) {
-            const userKey = localStorage.getItem("upcoming_user_key");
-            if (!userKey) return;
-            try {
-                const orderRef = doc(
-                    db,
-                    "companies",
-                    effectiveCompanyId,
-                    "Orders",
-                    `upcoming_${userKey}`
-                );
-                const snap = await getDoc(orderRef);
-                if (snap.exists()) {
-                    await setDoc(
-                        orderRef,
-                        { items: [], totalAmount: 0, updatedAt: serverTimestamp() },
-                        { merge: true }
-                    );
-                }
-            } catch (err) {
-                console.error("Sync Upcoming (empty cart) error:", err);
-            }
-            return;
-        }
+        if (!effectiveCompanyId || updatedCart.length === 0) return;
 
         const leadSubmittedCheck = localStorage.getItem("leadSubmitted") === "true";
         if (approvalEnabled && !leadSubmittedCheck) return;
@@ -462,14 +437,10 @@ const SharedProduct: React.FC = () => {
         }
     };
 
-    const isInitialCartSyncRef = useRef(true);
-
     useEffect(() => {
-        if (isInitialCartSyncRef.current) {
-            isInitialCartSyncRef.current = false;
-            return;
+        if (cart.length > 0) {
+            syncToUpcoming(cart);
         }
-        syncToUpcoming(cart);
     }, [cart]);
 
     useEffect(() => {

--- a/src/Components/NotificationBell.tsx
+++ b/src/Components/NotificationBell.tsx
@@ -26,7 +26,7 @@ const NotificationBell: React.FC = () => {
   return (
     <Popover onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
-        <div className="cursor-pointer relative flex items-center justify-center p-2 rounded-md hover:bg-slate-200 transition-colors">
+        <div className="cursor-pointer relative z-50 flex items-center justify-center p-2 rounded-md hover:bg-slate-200 transition-colors">
           <FiBell className="w-5 h-5" />
           {unreadCount > 0 && (
             <span className="absolute top-0 right-0 bg-red-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full translate-x-1 -translate-y-1">
@@ -43,7 +43,7 @@ const NotificationBell: React.FC = () => {
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="w-80 max-w-[90vw] p-0 shadow-lg sm:max-w-sm"      >
+        className="z-[9999] w-80 max-w-[90vw] p-0 shadow-lg sm:max-w-sm"      >
         {notifications.length === 0 ? (
           <p className="p-4 text-sm text-gray-500">No notifications</p>
         ) : (

--- a/src/Pages/Journal.tsx
+++ b/src/Pages/Journal.tsx
@@ -161,6 +161,7 @@ interface PdfData {
   companyState?: string;       // <-- ADD THIS
   billDiscount: number;
   discountDisplayFormat?: 'amount' | 'percentage';
+  enableDiscount2?: boolean;
   upiId: string;
   billTo: {
     name: string;
@@ -771,6 +772,7 @@ const Journal: React.FC = () => {
       placeOfSupply: invoice.placeOfSupply || '',
       billDiscount: invoice.manualDiscount || 0,
       discountDisplayFormat: billSettings?.discountDisplayFormat || 'amount',
+      enableDiscount2: salesSettings?.enableDiscount2 || false,
       upiId: billSettings.upiId || '',
       billTo: {
         name: invoice.partyName,

--- a/src/Pages/Settings/BillSetting.tsx
+++ b/src/Pages/Settings/BillSetting.tsx
@@ -279,7 +279,7 @@ const BillSettings: React.FC = () => {
                                 </div>
                                 <div className="md:col-span-2">
                                     <label className="block text-xs font-bold text-gray-500 uppercase mb-1">Registered Address</label>
-                                    <div className="p-3 bg-gray-50 border border-gray-200 rounded-sm text-gray-800 font-medium h-[44px] flex items-center truncate">
+                                    <div className="p-3 bg-gray-50 border border-gray-200 rounded-sm text-gray-800 font-medium min-h-[44px] flex items-center whitespace-normal break-words">
                                         {businessInfo.address}
                                     </div>
                                 </div>

--- a/src/Pages/Settings/ItemSetting.tsx
+++ b/src/Pages/Settings/ItemSetting.tsx
@@ -88,7 +88,7 @@ const SharedItemSettings: React.FC<SharedItemSettingsProps> = ({ theme = 'blue' 
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [modal, setModal] = useState<{ message: string; type: State } | null>(null);
 
-    const ToggleRow: React.FC<ToggleRowProps> = ({ id, label, description, checked, onChange, tooltip }) => {
+    const ToggleRow: React.FC<ToggleRowProps> = ({ id, label, checked, onChange, tooltip }) => {
         return (
             <div className="flex items-start justify-between py-3 border-b border-gray-100 last:border-0">
                 <div className="pr-4">
@@ -99,7 +99,6 @@ const SharedItemSettings: React.FC<SharedItemSettingsProps> = ({ theme = 'blue' 
                         {/* InfoTooltip correctly placed next to the label */}
                         {tooltip && <InfoTooltip text={tooltip} />}
                     </div>
-                    {description && <p className="text-xs text-gray-500 mt-0.5">{description}</p>}
                 </div>
                 <div className="flex items-center h-5 mt-1">
                     <button

--- a/src/Pages/Settings/Purchasesetting.tsx
+++ b/src/Pages/Settings/Purchasesetting.tsx
@@ -86,7 +86,6 @@ const ToggleRow: React.FC<ToggleRowProps> = ({ id, label, description, checked, 
                 <label htmlFor={id} className="text-sm font-semibold text-gray-800 leading-5">{label}</label>
                 <InfoTooltip text={tooltip || description} />
             </div>
-            <p className="hidden md:block text-xs text-gray-500 mt-1 leading-relaxed">{description}</p>
         </div>
         <label htmlFor={id} className="relative inline-flex cursor-pointer items-center">
             <input

--- a/src/Pages/Settings/SalesSetting.tsx
+++ b/src/Pages/Settings/SalesSetting.tsx
@@ -154,7 +154,6 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({ id, label, description, ch
                     <label htmlFor={id} className="text-sm font-semibold text-gray-800 leading-5">{label}</label>
                     <InfoTooltip text={tooltip || description} />
                 </div>
-                <p className="hidden md:block text-xs text-gray-500 mt-1 leading-relaxed">{description}</p>
             </div>
         </div>
         <label htmlFor={id} className="relative inline-flex cursor-pointer items-center">

--- a/src/UseComponents/pdfGenerator.ts
+++ b/src/UseComponents/pdfGenerator.ts
@@ -514,13 +514,13 @@ export const generatePdf = async (data: InvoiceData, action: ACTION.DOWNLOAD | A
     if (finalY > pageHeight - 80) { doc.addPage(); finalY = margin; }
     const vBoxX = endX - 25;
 
-    const addRow = (label: string, amt: number, h: number, noTopBorder: boolean = false, noBottomBorder: boolean = false) => {
+    const addRow = (label: string, amt: number, h: number, noTopBorder: boolean = false, noBottomBorder: boolean = false, bold: boolean = false) => {
       doc.line(startX, finalY, startX, finalY + h);                          // left
       doc.line(endX, finalY, endX, finalY + h);                              // right
       if (!noTopBorder) doc.line(startX, finalY, endX, finalY);              // top
       if (!noBottomBorder) doc.line(startX, finalY + h, endX, finalY + h);   // bottom
       doc.line(vBoxX, finalY, vBoxX, finalY + h);
-      doc.setFontSize(9); doc.setFont('helvetica', 'bold');
+      doc.setFontSize(9); doc.setFont('helvetica', bold ? 'bold' : 'normal');
       doc.text(label, vBoxX - 2, finalY + 4, { align: 'right' });
       doc.text(amt.toLocaleString('en-IN', { minimumFractionDigits: 2 }), endX - 2, finalY + 4, { align: 'right' });
       finalY += h;
@@ -644,7 +644,7 @@ export const generatePdf = async (data: InvoiceData, action: ACTION.DOWNLOAD | A
       doc.line(divX, finalY, divX, finalY + wordsH); doc.line(divX, finalY + 6, endX, finalY + 6);
       doc.setFont('helvetica', 'normal'); doc.text('Previous Balance :', divX + 2, finalY + 4.5);
       doc.text(prevBal.toLocaleString('en-IN', { minimumFractionDigits: 2 }), endX - 2, finalY + 4.5, { align: 'right' });
-      doc.setFont('helvetica', 'bold'); doc.text('Balance Due :', divX + 2, finalY + 10);
+      doc.setFont('helvetica', 'bold'); doc.text('Total Balance Due :', divX + 2, finalY + 10);
       doc.text(totalDue.toLocaleString('en-IN', { minimumFractionDigits: 2 }), endX - 2, finalY + 10, { align: 'right' });
     }
     finalY += wordsH;
@@ -688,10 +688,11 @@ export const generatePdf = async (data: InvoiceData, action: ACTION.DOWNLOAD | A
     doc.setTextColor(0); doc.setDrawColor(0);
 
     doc.setFont('helvetica', 'normal');
-    let mx = (pageWidth / 2) - ((doc.getTextWidth("Made with ") + doc.getTextWidth("Love") + doc.getTextWidth(" in India")) / 2);
-    doc.text("Made with ", mx, by + 10); mx += doc.getTextWidth("Made with ");
-    doc.setTextColor(255, 0, 0); doc.text("Love", mx, by + 10); mx += doc.getTextWidth("Love");
-    doc.setTextColor(0, 0, 139); doc.text(" in India", mx, by + 10); doc.setTextColor(0);
+let mx = (pageWidth / 2) - ((doc.getTextWidth("Made with ") + doc.getTextWidth("Love") + doc.getTextWidth(" in India")) / 2);
+doc.setTextColor(0, 0, 0);
+doc.text("Made with ", mx, by + 10); mx += doc.getTextWidth("Made with ");
+doc.text("Love", mx, by + 10); mx += doc.getTextWidth("Love");
+doc.text(" in India", mx, by + 10); doc.setTextColor(0);
   };
 
   // --- TRIGGER PAGE GENERATION ---

--- a/src/UseComponents/pdfGenerator.ts
+++ b/src/UseComponents/pdfGenerator.ts
@@ -25,6 +25,7 @@ export interface InvoiceData {
   signatureBase64?: string;
   billDiscount?: number;
   discountDisplayFormat?: 'amount' | 'percentage';
+  enableDiscount2?: boolean;
   upiId?: string;
   ifscCode?: number;
 
@@ -242,9 +243,15 @@ export const generatePdf = async (data: InvoiceData, action: ACTION.DOWNLOAD | A
       return v % 1 === 0 ? v.toFixed(0) : v.toFixed(1);
     };
 
-    const itemDiscDisplay = data.discountDisplayFormat === 'percentage'
-      ? `${fmtPct((item as any).discount1Percent)}% + ${fmtPct((item as any).discount2Percent)}%`
-      : `${disc1Amt.toFixed(2)} + ${disc2Amt.toFixed(2)}`;
+    const showDiscount2 = data.enableDiscount2 === true;
+
+    const itemDiscDisplay = showDiscount2
+      ? (data.discountDisplayFormat === 'percentage'
+        ? `${fmtPct((item as any).discount1Percent)}% + ${fmtPct((item as any).discount2Percent)}%`
+        : `${disc1Amt.toFixed(2)} + ${disc2Amt.toFixed(2)}`)
+      : (data.discountDisplayFormat === 'percentage'
+        ? `${fmtPct((item as any).discount1Percent)}%`
+        : `${disc1Amt.toFixed(2)}`);
 
     // 2. Pro-rate the global bill discount across rows
     let billDisc = sumPostDiscountAmounts > 0 ? (finalAmount / sumPostDiscountAmounts) * totalBillDiscount : 0;
@@ -480,7 +487,7 @@ export const generatePdf = async (data: InvoiceData, action: ACTION.DOWNLOAD | A
     cursorY += partyHeight;
 
     const fullTaxHeaders = isIgst
-      ? ['S.N.', 'Items', 'HSN', 'Qty', 'Unit', priceHeader, 'Discount', 'Bill Disc.','Subtotal', 'IGST', 'IGST Amt', 'Amount']
+      ? ['S.N.', 'Items', 'HSN', 'Qty', 'Unit', priceHeader, 'Discount', 'Bill Disc.', 'Subtotal', 'IGST', 'IGST Amt', 'Amount']
       : ['S.N.', 'Items', 'HSN', 'Qty', 'Unit', priceHeader, 'Discount', 'Bill Disc.', 'Subtotal', 'GST', 'GST Amt', 'Amount'];
 
     const noTaxHeaders = ['S.N.', 'Items', 'HSN', 'Qty', 'Unit', priceHeader, 'Discount', 'Bill Disc.', 'Amount'];


### PR DESCRIPTION
- Fixed the issue where Discount 2 was displayed even when the setting was disabled.
- Fixed the Daily Performance tutorial bar chart rendering empty on the Dashboard
- Fixed the notification bell popover appearing behind the header on the Orders page
- Applied UI fixes on the sales setting page ( cata)
- Removed duplicate information displayed in the Desktop view( pos/cata settings)
- Fixed the Registered Address field getting cut off on mobile devices( bill setting cata/pos)
- Added Print Bill functionality for Upcoming Orders
- Fixed the Upcoming Order timeline to display the correct count after item removal
- Fixed button UI and styling issues on the Upcoming Order page